### PR TITLE
Added calendar extension to php extensions

### DIFF
--- a/5/cli/Dockerfile
+++ b/5/cli/Dockerfile
@@ -18,7 +18,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
-	zip
+	zip \
+	calendar
 
 # Oro php settings
 RUN { \

--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -18,7 +18,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
-	zip
+	zip \
+	calendar
 
 # Oro php settings
 RUN { \

--- a/7/cli/Dockerfile
+++ b/7/cli/Dockerfile
@@ -18,7 +18,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
-	zip
+	zip \
+	calendar
 
 # Oro php settings
 RUN { \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -18,7 +18,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
-	zip
+	zip \
+	calendar
 
 # Oro php settings
 RUN { \


### PR DESCRIPTION
Needed `checkdomain/holiday v2.0.2` in orocrm.

Copying the error message from composer:
>   Problem 1
>    - Installation request for checkdomain/holiday v2.0.2 -> satisfiable by checkdomain/holiday[v2.0.2].
>    - checkdomain/holiday v2.0.2 requires ext-calendar * -> the
>requested PHP extension calendar is missing from your system.