### PR TITLE
Removed phpcs from *dev Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
   - ~/official-images/test/run.sh "$image"
   - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image git --version ; fi
   - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image phpunit --version ; fi
-  - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image phpcs --version ; fi
 
 after_script:
   - docker images

--- a/5/cli-dev/Dockerfile
+++ b/5/cli-dev/Dockerfile
@@ -15,12 +15,6 @@ RUN composer global require "hirak/prestissimo:^0.3"
 # Install phpunit
 RUN composer global require phpunit/phpunit 4.5.*
 
-# Install phpcs
-RUN set -xe \
-	&& composer global require squizlabs/php_codesniffer \
-	&& composer global require escapestudios/symfony2-coding-standard \
-	&& phpcs --config-set installed_paths ~/composer/vendor/escapestudios/symfony2-coding-standard
-
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/5/fpm-dev/Dockerfile
+++ b/5/fpm-dev/Dockerfile
@@ -15,12 +15,6 @@ RUN composer global require "hirak/prestissimo:^0.3"
 # Install phpunit
 RUN composer global require phpunit/phpunit 4.5.*
 
-# Install phpcs
-RUN set -xe \
-	&& composer global require squizlabs/php_codesniffer \
-	&& composer global require escapestudios/symfony2-coding-standard \
-	&& phpcs --config-set installed_paths ~/composer/vendor/escapestudios/symfony2-coding-standard
-
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/7/cli-dev/Dockerfile
+++ b/7/cli-dev/Dockerfile
@@ -15,12 +15,6 @@ RUN composer global require "hirak/prestissimo:^0.3"
 # Install phpunit
 RUN composer global require phpunit/phpunit 4.5.*
 
-# Install phpcs
-RUN set -xe \
-	&& composer global require squizlabs/php_codesniffer \
-	&& composer global require escapestudios/symfony2-coding-standard \
-	&& phpcs --config-set installed_paths ~/composer/vendor/escapestudios/symfony2-coding-standard
-
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/7/fpm-dev/Dockerfile
+++ b/7/fpm-dev/Dockerfile
@@ -15,12 +15,6 @@ RUN composer global require "hirak/prestissimo:^0.3"
 # Install phpunit
 RUN composer global require phpunit/phpunit 4.5.*
 
-# Install phpcs
-RUN set -xe \
-	&& composer global require squizlabs/php_codesniffer \
-	&& composer global require escapestudios/symfony2-coding-standard \
-	&& phpcs --config-set installed_paths ~/composer/vendor/escapestudios/symfony2-coding-standard
-
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
phpcs is not in use and can therefor be deleted. We delete it because
it prevents a sucessfull build of the images.