### PR TITLE
Update nodejs dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_script:
 script:
   - docker build -t "$image" "${VARIANT}"
   - ~/official-images/test/run.sh "$image"
+  - docker run -it --rm $image node --version
+  - docker run -it --rm $image npm --version
   - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image git --version ; fi
   - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image phpunit --version ; fi
 

--- a/5/cli/Dockerfile
+++ b/5/cli/Dockerfile
@@ -1,14 +1,27 @@
 FROM php:5.6-cli
 
+ENV NODEREPO node_4.x
+
 # Install dependencies
 # apt-get update is called during the nodejs install script
 # See https://deb.nodesource.com/setup
-RUN wget -qO- https://deb.nodesource.com/setup | bash - \
-	&& apt-get install -y \
+RUN set -xe \
+	\
+	# Add nodejs repo (jessie is coming from php) and deps to it
+	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
+	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
+	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
+	\
+	# Install deps
+	&& apt-get update && apt-get install -y \
 		libicu-dev \
+		zlib1g-dev \
 		libmcrypt-dev \
 		libpng-dev \
 		libxml2-dev \
+		libicu52 \
+		zlib1g \
 		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 

--- a/5/cli/Dockerfile
+++ b/5/cli/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
 		libicu52 \
 		zlib1g \
 		nodejs \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	--no-install-recommends && apt-get remove --purge -y apt-transport-https && rm -r /var/lib/apt/lists/*
 
 # Install extensions
 RUN docker-php-ext-install \

--- a/5/cli/Dockerfile
+++ b/5/cli/Dockerfile
@@ -1,12 +1,15 @@
 FROM php:5.6-cli
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-		nodejs \
+# apt-get update is called during the nodejs install script
+# See https://deb.nodesource.com/setup
+RUN wget -qO- https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -y \
 		libicu-dev \
 		libmcrypt-dev \
 		libpng-dev \
 		libxml2-dev \
+		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install extensions

--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -1,14 +1,27 @@
 FROM php:5.6-fpm
 
+ENV NODEREPO node_4.x
+
 # Install dependencies
 # apt-get update is called during the nodejs install script
 # See https://deb.nodesource.com/setup
-RUN wget -qO- https://deb.nodesource.com/setup | bash - \
-	&& apt-get install -y \
+RUN set -xe \
+	\
+	# Add nodejs repo (jessie is coming from php) and deps to it
+	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
+	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
+	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
+	\
+	# Install deps
+	&& apt-get update && apt-get install -y \
 		libicu-dev \
+		zlib1g-dev \
 		libmcrypt-dev \
 		libpng-dev \
 		libxml2-dev \
+		libicu52 \
+		zlib1g \
 		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 

--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -1,12 +1,15 @@
 FROM php:5.6-fpm
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-		nodejs \
+# apt-get update is called during the nodejs install script
+# See https://deb.nodesource.com/setup
+RUN wget -qO- https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -y \
 		libicu-dev \
 		libmcrypt-dev \
 		libpng-dev \
 		libxml2-dev \
+		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install extensions

--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
 		libicu52 \
 		zlib1g \
 		nodejs \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	--no-install-recommends && apt-get remove --purge -y apt-transport-https && rm -r /var/lib/apt/lists/*
 
 # Install extensions
 RUN docker-php-ext-install \

--- a/7/cli/Dockerfile
+++ b/7/cli/Dockerfile
@@ -1,8 +1,10 @@
 FROM php:7.1-cli
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-		nodejs \
+# apt-get update is called during the nodejs install script
+# See https://deb.nodesource.com/setup
+RUN wget -qO- https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -y \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \
@@ -10,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libicu52 \
 		zlib1g \
+		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install extensions

--- a/7/cli/Dockerfile
+++ b/7/cli/Dockerfile
@@ -1,10 +1,20 @@
 FROM php:7.1-cli
 
+ENV NODEREPO node_4.x
+
 # Install dependencies
 # apt-get update is called during the nodejs install script
 # See https://deb.nodesource.com/setup
-RUN wget -qO- https://deb.nodesource.com/setup | bash - \
-	&& apt-get install -y \
+RUN set -xe \
+	\
+	# Add nodejs repo (jessie is coming from php) and deps to it
+	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
+	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
+	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
+	\
+	# Install deps
+	&& apt-get update && apt-get install -y \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \

--- a/7/cli/Dockerfile
+++ b/7/cli/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
 		libicu52 \
 		zlib1g \
 		nodejs \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	--no-install-recommends && apt-get remove --purge -y apt-transport-https && rm -r /var/lib/apt/lists/*
 
 # Install extensions
 RUN docker-php-ext-install \

--- a/7/fpm-dev/Dockerfile
+++ b/7/fpm-dev/Dockerfile
@@ -1,5 +1,7 @@
 FROM banovo/php:7-fpm
 
+ENV NODEREPO node_4.x
+
 # Set environmental variables
 ENV COMPOSER_HOME /root/composer
 ENV PATH $COMPOSER_HOME/vendor/bin:$PATH

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
 		libicu52 \
 		zlib1g \
 		nodejs \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	--no-install-recommends && apt-get remove --purge -y apt-transport-https && rm -r /var/lib/apt/lists/*
 
 # Install extensions
 RUN docker-php-ext-install \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,8 +1,10 @@
 FROM php:7.1-fpm
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-		nodejs \
+# apt-get update is called during the nodejs install script
+# See https://deb.nodesource.com/setup
+RUN wget -qO- https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -y \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \
@@ -10,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 		libxml2-dev \
 		libicu52 \
 		zlib1g \
+		nodejs \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install extensions

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,10 +1,20 @@
 FROM php:7.1-fpm
 
+ENV NODEREPO node_4.x
+
 # Install dependencies
 # apt-get update is called during the nodejs install script
 # See https://deb.nodesource.com/setup
-RUN wget -qO- https://deb.nodesource.com/setup | bash - \
-	&& apt-get install -y \
+RUN set -xe \
+	\
+	# Add nodejs repo (jessie is coming from php) and deps to it
+	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
+	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
+	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
+	\
+	# Install deps
+	&& apt-get update && apt-get install -y \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \


### PR DESCRIPTION
The `nodejs` package from the offical ubuntu repos is  an old
version and misses npm.

We need npm for some of the vendors from now on.

I added the [nodejs binary repo](https://github.com/nodesource/distributions)
type of installation by running a bash script provided the node team.

It's related to our internal issue ids [ch397], [ch379].