### PR TITLE
Fix text file busy travis bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@ before_script:
 script:
   - docker build -t "$image" "${VARIANT}"
   - ~/official-images/test/run.sh "$image"
-  - if ! [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image node --version ; fi
-  - if ! [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image npm --version ; fi
-  - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image git --version ; fi
-  - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image phpunit --version ; fi
+  # Adding sync command to prevent "text file busy" errors during travis build.
+  - if ! [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image sync && node --version ; fi
+  - if ! [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image sync && npm --version ; fi
+  - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image sync && git --version ; fi
+  - if [[ $VARIANT =~ ^....dev ]] ; then docker run -it --rm $image sync && phpunit --version ; fi
 
 after_script:
   - docker images


### PR DESCRIPTION
Fix the bug "text file busy" during travis checks.
It looks like a known issue to in moby (moby/moby/#9547)
and seems to be a resource problem.

Adding a `sync` line fixes that problem as far as I can see.