### PR TITLE
Add missing phantom dependency

### DIFF
--- a/5/fpm-dev/Dockerfile
+++ b/5/fpm-dev/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 # Install composer
 RUN set -xe \
-	&& apt-get update && apt-get install -y git --no-install-recommends && rm -r /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y git libfontconfig1 --no-install-recommends && rm -r /var/lib/apt/lists/* \
 	&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install prestissimo for faster composer installations

--- a/7/cli-dev/Dockerfile
+++ b/7/cli-dev/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 # Install composer
 RUN set -xe \
-	&& apt-get update && apt-get install -y git --no-install-recommends && rm -r /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y git libfontconfig1 --no-install-recommends && rm -r /var/lib/apt/lists/* \
 	&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install prestissimo for faster composer installations

--- a/7/fpm-dev/Dockerfile
+++ b/7/fpm-dev/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 # Install composer
 RUN set -xe \
-	&& apt-get update && apt-get install -y git --no-install-recommends && rm -r /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y git libfontconfig1 --no-install-recommends && rm -r /var/lib/apt/lists/* \
 	&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install prestissimo for faster composer installations


### PR DESCRIPTION
The dependency is required to run phantomjs.

In commit 8f926fc introduces the dependency to the php5 cli dev
container but misses the other dev containers. (See #33)

I just added the dep to the other dev containers.