### PR TITLE
Fix base container

### DIFF
--- a/5/fpm-dev/Dockerfile
+++ b/5/fpm-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM banovo/php:5-fpm
+FROM banovo/php:5
 
 # Set environmental variables
 ENV COMPOSER_HOME /root/composer

--- a/7/fpm-dev/Dockerfile
+++ b/7/fpm-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM banovo/php:7-fpm
+FROM banovo/php:7
 
 ENV NODEREPO node_4.x
 


### PR DESCRIPTION
The "dev" container need to be based on the new tags `5` and `7`,
because the `5-fpm` and `7-fpm` tag do not exist anymore.