### PR TITLE
Add entrypoint loader

### DIFF
--- a/5/fpm-dev/docker-entrypoint.sh
+++ b/5/fpm-dev/docker-entrypoint.sh
@@ -6,7 +6,18 @@ if [[ "$1" == -* ]]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p /var/www /usr/local/bin
+logger "Fixing rights in container"
+mkdir -p /var/www
 chown -R www-data:www-data /var/www /usr/local/bin
+
+# docker-entrypoint-initdb.d, as provided by most official images allows for direct usage and extended images to
+# extend behaviour without modifying this file.
+for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+        *.sh)     logger "$0: running $f"; . "$f" ;;
+        "/docker-entrypoint-initdb.d/*") ;;
+        *)        logger "$0: ignoring $f" ;;
+    esac
+done
 
 exec "$@"

--- a/5/fpm/docker-entrypoint.sh
+++ b/5/fpm/docker-entrypoint.sh
@@ -6,7 +6,18 @@ if [[ "$1" == -* ]]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p /var/www /usr/local/bin
+logger "Fixing rights in container"
+mkdir -p /var/www
 chown -R www-data:www-data /var/www /usr/local/bin
+
+# docker-entrypoint-initdb.d, as provided by most official images allows for direct usage and extended images to
+# extend behaviour without modifying this file.
+for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+        *.sh)     logger "$0: running $f"; . "$f" ;;
+        "/docker-entrypoint-initdb.d/*") ;;
+        *)        logger "$0: ignoring $f" ;;
+    esac
+done
 
 exec "$@"

--- a/7/fpm-dev/docker-entrypoint.sh
+++ b/7/fpm-dev/docker-entrypoint.sh
@@ -6,7 +6,18 @@ if [[ "$1" == -* ]]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p /var/www /usr/local/bin
+logger "Fixing rights in container"
+mkdir -p /var/www
 chown -R www-data:www-data /var/www /usr/local/bin
+
+# docker-entrypoint-initdb.d, as provided by most official images allows for direct usage and extended images to
+# extend behaviour without modifying this file.
+for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+        *.sh)     logger "$0: running $f"; . "$f" ;;
+        "/docker-entrypoint-initdb.d/*") ;;
+        *)        logger "$0: ignoring $f" ;;
+    esac
+done
 
 exec "$@"

--- a/7/fpm/docker-entrypoint.sh
+++ b/7/fpm/docker-entrypoint.sh
@@ -6,7 +6,18 @@ if [[ "$1" == -* ]]; then
 	set -- php-fpm "$@"
 fi
 
-mkdir -p /var/www /usr/local/bin
+logger "Fixing rights in container"
+mkdir -p /var/www
 chown -R www-data:www-data /var/www /usr/local/bin
+
+# docker-entrypoint-initdb.d, as provided by most official images allows for direct usage and extended images to
+# extend behaviour without modifying this file.
+for f in /docker-entrypoint-initdb.d/*; do
+    case "$f" in
+        *.sh)     logger "$0: running $f"; . "$f" ;;
+        "/docker-entrypoint-initdb.d/*") ;;
+        *)        logger "$0: ignoring $f" ;;
+    esac
+done
 
 exec "$@"


### PR DESCRIPTION
This commit adds the ability to run entrypoint scripts added to the
folder `/docker-entrypoint-initdb.d/*`. It will typically be used by
adding script with volumes.

It's a handy possibility to add multiple bash scripts.