### PR TITLE
Fixing docker hub build apt-get error

### DIFF
--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -8,13 +8,13 @@ ENV NODEREPO node_8.x
 RUN set -xe \
 	\
 	# Add nodejs repo (jessie is coming from php) and deps to it
-	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& apt-get update && apt-get install -y --force-yes apt-transport-https --no-install-recommends \
 	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
 	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
 	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
 	\
 	# Install deps
-	&& apt-get update && apt-get install -y \
+	&& apt-get update && apt-get install -y --force-yes \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -8,13 +8,13 @@ ENV NODEREPO node_8.x
 RUN set -xe \
 	\
 	# Add nodejs repo (jessie is coming from php) and deps to it
-	&& apt-get update && apt-get install -y apt-transport-https --no-install-recommends \
+	&& apt-get update && apt-get install -y --force-yes apt-transport-https --no-install-recommends \
 	&& php -r "echo file_get_contents('https://deb.nodesource.com/gpgkey/nodesource.gpg.key');" | apt-key add - \
 	&& echo "deb https://deb.nodesource.com/${NODEREPO} jessie main" > /etc/apt/sources.list.d/nodesource.list \
 	&& echo "deb-src https://deb.nodesource.com/${NODEREPO} jessie main" >> /etc/apt/sources.list.d/nodesource.list \
 	\
 	# Install deps
-	&& apt-get update && apt-get install -y \
+	&& apt-get update && apt-get install -y --force-yes \
 		libicu-dev \
 		zlib1g-dev \
 		libmcrypt-dev \


### PR DESCRIPTION
There occurs an error on docker hub only:
>  There are problems and -y was used without --force-yes

I don't know why this happens on docker hub only and not on travis
or locally, but I can fix it by simply adding the `--force-yes` flag.