### PR TITLE
Add extension exif and fileinfo

### DIFF
--- a/5/fpm/Dockerfile
+++ b/5/fpm/Dockerfile
@@ -35,6 +35,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
+	exif \
+	fileinfo \
 	zip
 
 # Oro php settings

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -35,6 +35,8 @@ RUN docker-php-ext-install \
 	opcache \
 	pdo_mysql \
 	soap \
+	exif \
+	fileinfo \
 	zip
 
 RUN pecl install \


### PR DESCRIPTION
Add the `exif` and `fileinfo`  extension because it's needed for
bolt.cm thumbnail generation.

Related internal ticket [ch-939]