### PR TITLE
MOS-261 Fix CI for MOSAIC

### DIFF
--- a/7/fpm-dev-mosaic/Dockerfile
+++ b/7/fpm-dev-mosaic/Dockerfile
@@ -20,6 +20,7 @@ RUN set -xe \
 		libicu57 \
 		zlib1g \
 		sudo \
+		ssh-client \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install extensions


### PR DESCRIPTION
Add SSH client, so that ssh operations can be performed for CI.
Please review and see if its ok.